### PR TITLE
deps: Enable updates via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]


### PR DESCRIPTION
While in the context of this project it's far more often noise than genuine problem, it can be a source of vulnerability scanner noise due to sensitive dependencies like `x/crypto` and others.

This aims to reduce that noise. It does not mean we shouldn't assess the real impact of CVEs though, it just automates part of that process. i.e. assessments can be done as part of each individual dependabot PR.