### PR TITLE
Coverage test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,4 @@
-on:
-  push:
-    branches: [coverage-test]
+on: [push, pull_request]
 name: Test
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,12 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [coverage-test]
 name: Test
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.23]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -17,4 +19,11 @@ jobs:
     - name: Check that WASM builds
       run: GOOS=js GOARCH=wasm go build -o test.wasm .
     - name: Test
-      run: go test ./...
+      run: go test -v -coverprofile=coverage.out ./...
+    - name: Upload coverage report 
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+      with:
+        path: coverage.out
+        name: coverage-report
+    - name: Display coverage report
+      run: go tool cover -func=coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/cli
 
-go 1.20
+go 1.23
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
- The unit test coverage was added to the existing workflow.
- The unit test coverage change was done to help understand the defects early in lifecycle and come up with a good solution for it.
- The go-version has been updated to 1.23 from 1.20.